### PR TITLE
Add define for O_TMPFILE

### DIFF
--- a/include/asm-generic/fcntl.h
+++ b/include/asm-generic/fcntl.h
@@ -84,6 +84,14 @@
 #define O_PATH		010000000
 #endif
 
+#ifndef __O_TMPFILE
+#define __O_TMPFILE	020000000
+#endif
+
+/* a horrid kludge trying to make sure that this will fail on old kernels */
+#define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
+#define O_TMPFILE_MASK (__O_TMPFILE | O_DIRECTORY | O_CREAT)
+
 #ifndef O_NDELAY
 #define O_NDELAY	O_NONBLOCK
 #endif


### PR DESCRIPTION
Until we have a proper backport of the feature, this seems
to do the trick for fixing build issues in Android Pie.

Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>

source: https://review.lineageos.org/c/LineageOS/android_kernel_samsung_msm8974/+/234754